### PR TITLE
docs(preamble): :memo: add yml header with tbl-colwidths

### DIFF
--- a/preamble/schedule.qmd
+++ b/preamble/schedule.qmd
@@ -1,3 +1,7 @@
+---
+tbl-colwidths: [20, 80]
+---
+
 # Schedule {#sec-schedule}
 
 {{< include ../includes/_wip.qmd >}}


### PR DESCRIPTION
## Description

This aligns the column width across schedule tables. 

I found out that the difference in col widths (Day 1 and 2 were the same and Day 3 slightly different) were bc the first two days having longer texts (the social activity with networking). We can remedy this by fixing the colwidths in the yaml header.

## Reviewer Focus

This PR needs a quick review. 

Focus on CHANGES.

## Checklist
- [ ] Ran spell check
- [ ] Formatted Markdown
- [X] Rendered website locally
